### PR TITLE
Add support for field tags in Mustache paths.

### DIFF
--- a/lookup.go
+++ b/lookup.go
@@ -45,7 +45,7 @@ func lookup(name string, context ...interface{}) (interface{}, bool) {
 		// names in our templates which makes it more mustache like.
 		case reflect.Struct:
 			field := reflectValue.FieldByName(name)
-			if field.IsValid() {
+			if field.IsValid() && field.CanInterface() {
 				return field.Interface(), truth(field)
 			}
 			method := reflectValue.MethodByName(name)

--- a/lookup.go
+++ b/lookup.go
@@ -54,6 +54,21 @@ func lookup(name string, context ...interface{}) (interface{}, bool) {
 				return out.Interface(), truth(out)
 			}
 
+			typ := reflectValue.Type()
+			for i := 0; i < typ.NumField(); i++ {
+				f := typ.Field(i)
+				if f.PkgPath != "" {
+					continue
+				}
+				tag := f.Tag.Get("mustache")
+				if tag == name {
+					field := reflectValue.Field(i)
+					if field.IsValid() {
+						return field.Interface(), truth(field)
+					}
+				}
+			}
+
 		}
 		// If by this point no value was matched, we'll move up a step in the
 		// chain and try to match a value there.

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -42,8 +42,9 @@ func TestSimpleLookup(t *testing.T) {
 				String  string
 				Boolean bool
 				Nested  struct{ Inside string }
+				Tagged  string `mustache:"newName"`
 			}{
-				123, "abc", true, struct{ Inside string }{"I'm nested!"},
+				123, "abc", true, struct{ Inside string }{"I'm nested!"}, "xyz",
 			},
 			assertions: []struct {
 				name  string
@@ -54,6 +55,7 @@ func TestSimpleLookup(t *testing.T) {
 				{"String", "abc", true},
 				{"Boolean", true, true},
 				{"Nested.Inside", "I'm nested!", true},
+				{"newName", "xyz", true},
 			},
 		},
 	} {

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -43,8 +43,9 @@ func TestSimpleLookup(t *testing.T) {
 				Boolean bool
 				Nested  struct{ Inside string }
 				Tagged  string `mustache:"newName"`
+				bad     string
 			}{
-				123, "abc", true, struct{ Inside string }{"I'm nested!"}, "xyz",
+				123, "abc", true, struct{ Inside string }{"I'm nested!"}, "xyz", "bad",
 			},
 			assertions: []struct {
 				name  string
@@ -56,6 +57,8 @@ func TestSimpleLookup(t *testing.T) {
 				{"Boolean", true, true},
 				{"Nested.Inside", "I'm nested!", true},
 				{"newName", "xyz", true},
+				{"Tagged", "xyz", true},
+				{"bad", nil, false},
 			},
 		},
 	} {


### PR DESCRIPTION
This lets you customize the paths you can access when using structs in the mustache payload.