### PR TITLE
Change whitespace handling to use a trim approach

### DIFF
--- a/lex_test.go
+++ b/lex_test.go
@@ -48,6 +48,20 @@ func TestLexer(t *testing.T) {
 				{typ: tokenEOF},
 			},
 		},
+		{
+			"foo {{bar.with space}}\n{{ trim }}",
+			[]token{
+				{typ: tokenText, val: "foo "},
+				{typ: tokenLeftDelim, val: "{{"},
+				{typ: tokenIdentifier, val: "bar.with space"},
+				{typ: tokenRightDelim, val: "}}"},
+				{typ: tokenText, val: "\n"},
+				{typ: tokenLeftDelim, val: "{{"},
+				{typ: tokenIdentifier, val: "trim"},
+				{typ: tokenRightDelim, val: "}}"},
+				{typ: tokenEOF},
+			},
+		},
 	} {
 		var (
 			lexer = newLexer(test.template, "{{", "}}")

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -162,3 +162,21 @@ func TestObjectOutputUnescaped(t *testing.T) {
 		t.Errorf("expected %q got %q", expected, output.String())
 	}
 }
+
+func TestInterpolationWithWhitespace(t *testing.T) {
+	input := strings.NewReader("some text {{foo.bar baz.foo}} here")
+	template := New()
+	err := template.Parse(input)
+	if err != nil {
+		t.Error(err)
+	}
+	var output bytes.Buffer
+	err = template.Render(&output, map[string]map[string]map[string]string{"foo": {"bar baz": {"foo": "bar %2B"}}})
+	if err != nil {
+		t.Error(err)
+	}
+	expected := "some text bar %2B here"
+	if output.String() != expected {
+		t.Errorf("expected %q got %q", expected, output.String())
+	}
+}


### PR DESCRIPTION
Currently whitespace breaks an ident token but it should just be
trimmed.
