### PR TITLE
Conditional test_value section

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -85,16 +85,16 @@ type stateFn func(*lexer) stateFn
 
 // lexer holds the state of the scanner.
 type lexer struct {
-	name             string     // the name of the input; used only for error reports.
-	input            string     // the string being scanned.
-	leftDelim        string     // start of action.
-	rightDelim       string     // end of action.
-	state            stateFn    // the next lexing function to enter.
-	pos              int        // current position in the input.
-	start            int        // start position of this token.
-	width            int        // width of last rune read from input.
-	tokens           chan token // channel of scanned tokens.
-	testValueSection bool       // supports non-standard {{#has_value <ident> value}}
+	name                string     // the name of the input; used only for error reports.
+	input               string     // the string being scanned.
+	leftDelim           string     // start of action.
+	rightDelim          string     // end of action.
+	state               stateFn    // the next lexing function to enter.
+	pos                 int        // current position in the input.
+	start               int        // start position of this token.
+	width               int        // width of last rune read from input.
+	tokens              chan token // channel of scanned tokens.
+	useTestValueSection bool       // supports non-standard {{#test_value <ident> value}}
 }
 
 // next returns the next rune in the input.
@@ -199,11 +199,11 @@ func (l *lexer) String() string {
 // newLexer creates a new scanner for the input string.
 func newLexer(input, left, right string, testValueSection bool) *lexer {
 	l := &lexer{
-		input:            input,
-		leftDelim:        left,
-		rightDelim:       right,
-		tokens:           make(chan token, 2),
-		testValueSection: testValueSection,
+		input:               input,
+		leftDelim:           left,
+		rightDelim:          right,
+		tokens:              make(chan token, 2),
+		useTestValueSection: testValueSection,
 	}
 	l.state = stateText // initial state
 	return l
@@ -322,7 +322,7 @@ func stateTag(l *lexer) stateFn {
 	if strings.HasPrefix(l.input[l.pos:], l.rightDelim) {
 		return stateRightDelim
 	}
-	if l.testValueSection && strings.HasPrefix(l.input[l.pos:], "#test_value") {
+	if l.useTestValueSection && strings.HasPrefix(l.input[l.pos:], "#test_value") {
 		return stateTest
 	}
 	switch r := l.next(); {

--- a/lex_test.go
+++ b/lex_test.go
@@ -62,9 +62,28 @@ func TestLexer(t *testing.T) {
 				{typ: tokenEOF},
 			},
 		},
+		{
+			"foo {{#test_value {{foo}} \"bar\"}}{{/test_value}}",
+			[]token{
+				{typ: tokenText, val: "foo "},
+				{typ: tokenLeftDelim, val: "{{"},
+				{typ: tokenTestValue, val: "#"},
+				{typ: tokenIdentifier, val: "test_value"},
+				{typ: tokenLeftDelim, val: "{{"},
+				{typ: tokenIdentifier, val: "foo"},
+				{typ: tokenRightDelim, val: "}}"},
+				{typ: tokenText, val: "bar"},
+				{typ: tokenRightDelim, val: "}}"},
+				{typ: tokenLeftDelim, val: "{{"},
+				{typ: tokenSectionEnd, val: "/"},
+				{typ: tokenIdentifier, val: "test_value"},
+				{typ: tokenRightDelim, val: "}}"},
+				{typ: tokenEOF},
+			},
+		},
 	} {
 		var (
-			lexer = newLexer(test.template, "{{", "}}")
+			lexer = newLexer(test.template, "{{", "}}", true)
 			token = lexer.token()
 			i     = 0
 		)

--- a/mustache.go
+++ b/mustache.go
@@ -121,6 +121,28 @@ func (n *sectionNode) render(t *Template, w *writer, c ...interface{}) error {
 	return fmt.Errorf("failed to lookup %s", n.name)
 }
 
+// The testNode type is a complex node which recursively renders its child
+// elements while passing along its context along with the global context.
+type testNode struct {
+	testIdent string
+	testVal   string
+	elems     []node
+}
+
+func (n *testNode) render(t *Template, w *writer, c ...interface{}) error {
+	w.tag()
+	defer w.tag()
+	v, _ := lookup(n.testIdent, c...)
+	vs := strings.Builder{}
+	print(&vs, v, noEscape)
+	if vs.String() == n.testVal {
+		for _, elem := range n.elems {
+			elem.render(t, w, c...)
+		}
+	}
+	return nil
+}
+
 func (n *sectionNode) String() string {
 	return fmt.Sprintf("[section: %q inv: %t elems: %s]", n.name, n.inverted, n.elems)
 }
@@ -295,26 +317,36 @@ func JsonEscape() Option {
 	}
 }
 
+// If you specify this option, then this Template will support
+// {{#test_value ident value}} sections
+func TestValueSection() Option {
+	return func(t *Template) {
+		t.testValueSection = true
+	}
+}
+
 // The Template type represents a template and its components.
 type Template struct {
-	name       string
-	elems      []node
-	partials   map[string]*Template
-	startDelim string
-	endDelim   string
-	silentMiss bool
-	escape     escapeType
+	name             string
+	elems            []node
+	partials         map[string]*Template
+	startDelim       string
+	endDelim         string
+	silentMiss       bool
+	testValueSection bool
+	escape           escapeType
 }
 
 // New returns a new Template instance.
 func New(options ...Option) *Template {
 	t := &Template{
-		elems:      make([]node, 0),
-		partials:   make(map[string]*Template),
-		startDelim: "{{",
-		endDelim:   "}}",
-		silentMiss: true,
-		escape:     htmlEscape,
+		elems:            make([]node, 0),
+		partials:         make(map[string]*Template),
+		startDelim:       "{{",
+		endDelim:         "}}",
+		silentMiss:       true,
+		testValueSection: false,
+		escape:           htmlEscape,
 	}
 	t.Option(options...)
 	return t
@@ -334,7 +366,7 @@ func (t *Template) Parse(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	l := newLexer(string(b), t.startDelim, t.endDelim)
+	l := newLexer(string(b), t.startDelim, t.endDelim, t.testValueSection)
 	p := newParser(l, t.escape)
 	elems, err := p.parse()
 	if err != nil {

--- a/mustache.go
+++ b/mustache.go
@@ -133,11 +133,13 @@ func (n *testNode) render(t *Template, w *writer, c ...interface{}) error {
 	w.tag()
 	defer w.tag()
 	v, _ := lookup(n.testIdent, c...)
-	vs := strings.Builder{}
-	print(&vs, v, noEscape)
-	if vs.String() == n.testVal {
-		for _, elem := range n.elems {
-			elem.render(t, w, c...)
+	if v != nil {
+		vs := strings.Builder{}
+		print(&vs, v, noEscape)
+		if vs.String() == n.testVal {
+			for _, elem := range n.elems {
+				elem.render(t, w, c...)
+			}
 		}
 	}
 	return nil

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -9,12 +9,6 @@ import (
 	"testing"
 )
 
-var tests = map[string]interface{}{
-	"some text {{foo}} here":                   map[string]string{"foo": "bar"},
-	"{{#foo}} foo is defined {{bar}} {{/foo}}": map[string]map[string]string{"foo": {"bar": "baz"}},
-	"{{^foo}} foo is defined {{bar}} {{/foo}}": map[string]map[string]string{"foo": {"bar": "baz"}},
-}
-
 func TestTemplate(t *testing.T) {
 	input := strings.NewReader("some text {{foo}} here")
 	template := New()
@@ -179,4 +173,48 @@ func TestInterpolationWithWhitespace(t *testing.T) {
 	if output.String() != expected {
 		t.Errorf("expected %q got %q", expected, output.String())
 	}
+}
+
+type templateTest struct {
+	template string
+	payload  interface{}
+	expect   string
+}
+
+func TestSectionTestValue(t *testing.T) {
+	tests := []templateTest{
+		{ // test basic
+			`some text {{#test_value {{a}} "value"}}hidden{{/test_value}} here`,
+			map[string]string{"a": "value"},
+			`some text hidden here`,
+		},
+		{ // Expect top level context.
+			`some text {{#test_value {{a}} "value"}}{{b}}{{/test_value}} here`,
+			map[string]string{"a": "value", "b": "hidden"},
+			`some text hidden here`,
+		},
+		{ // Test nesting.
+			`some text {{#test_value {{a}} "value"}}{{#test_value {{b}} "hidden"}}thing{{/test_value}}{{/test_value}} here`,
+			map[string]string{"a": "value", "b": "hidden"},
+			`some text thing here`,
+		},
+	}
+	for _, test := range tests {
+		input := strings.NewReader(test.template)
+		template := New(TestValueSection())
+		err := template.Parse(input)
+		if err != nil {
+			t.Error(err)
+		}
+		var output bytes.Buffer
+		err = template.Render(&output, test.payload)
+		if err != nil {
+			t.Error(err)
+		}
+		if output.String() != test.expect {
+			t.Errorf("expected %q got %q", test.expect, output.String())
+		}
+
+	}
+
 }

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -198,6 +198,16 @@ func TestSectionTestValue(t *testing.T) {
 			map[string]string{"a": "value", "b": "hidden"},
 			`some text thing here`,
 		},
+		{ // test nil lookup
+			`some text {{#test_value {{aa}} "value"}}hidden{{/test_value}} here`,
+			map[string]string{"a": "value"},
+			`some text  here`,
+		},
+		{ // Test nesting normal section
+			`some text {{#test_value {{a}} "value"}}{{#b}}{{.}}{{/b}}{{/test_value}} here`,
+			map[string]interface{}{"a": "value", "b": []int{1, 2, 3}},
+			`some text 123 here`,
+		},
 	}
 	for _, test := range tests {
 		input := strings.NewReader(test.template)

--- a/parse.go
+++ b/parse.go
@@ -178,6 +178,8 @@ func (p *parser) parseTag() (node, error) {
 		return p.parseSection(true)
 	case tokenSectionStart:
 		return p.parseSection(false)
+	case tokenTestValue:
+		return p.parseTest()
 	case tokenPartial:
 		return p.parsePartial()
 	}
@@ -287,6 +289,71 @@ func (p *parser) parsePartial() (node, error) {
 		return nil, p.errorf(t, "unexpected token %s", t)
 	}
 	return &partialNode{t.val}, nil
+}
+
+// parseSection parses a test_Value block. It is assumed that the next read should
+// return a t_section token.
+func (p *parser) parseTest() (node, error) {
+	t := p.read()
+	if t.typ != tokenIdentifier {
+		return nil, p.errorf(t, "unexpected token %s", t)
+	}
+	if next := p.read(); next.typ != tokenLeftDelim {
+		return nil, p.errorf(next, "unexpected token %s", next)
+	}
+	i := p.read()
+	if i.typ != tokenIdentifier {
+		return nil, p.errorf(i, "unexpected token %s", i)
+	}
+	if next := p.read(); next.typ != tokenRightDelim {
+		return nil, p.errorf(next, "unexpected token %s", next)
+	}
+
+	v := p.read()
+	if v.typ != tokenText {
+		return nil, p.errorf(v, "unexpected token %s", v)
+	}
+
+	if next := p.read(); next.typ != tokenRightDelim {
+		return nil, p.errorf(next, "unexpected token %s", next)
+	}
+
+	var (
+		tokens []token
+		stack  = 1
+	)
+	for {
+		read, err := p.readv(t)
+		if err != nil {
+			return nil, err
+		}
+		tokens = append(tokens, read...)
+		if len(read) > 1 {
+			// Check the token that preceeded the matching identifier. For
+			// section start and inverse tokens we increase the stack, otherwise
+			// decrease.
+			tt := read[len(read)-2]
+			switch {
+			case tt.typ == tokenTestValue:
+				stack++
+			case tt.typ == tokenSectionEnd:
+				stack--
+			}
+		}
+		if stack == 0 {
+			break
+		}
+	}
+	nodes, err := subParser(tokens[:len(tokens)-3], p.escape).parse()
+	if err != nil {
+		return nil, err
+	}
+	section := &testNode{
+		testIdent: i.val,
+		testVal:   v.val,
+		elems:     nodes,
+	}
+	return section, nil
 }
 
 // newParser creates a new parser using the suppliad lexer.

--- a/parse_test.go
+++ b/parse_test.go
@@ -78,6 +78,16 @@ func TestParser(t *testing.T) {
 			},
 		},
 		{
+			"{{#test_value {{foo}} \"bar\"}}({{a}a}}){{/test_value}}",
+			[]node{
+				&testNode{"foo", "bar", []node{
+					textNode("("),
+					&varNode{"a}a", htmlEscape},
+					textNode(")"),
+				}},
+			},
+		},
+		{
 			"{{#list}}({{a}a}}){{/list}}",
 			[]node{
 				&sectionNode{"list", false, []node{
@@ -88,7 +98,7 @@ func TestParser(t *testing.T) {
 			},
 		},
 	} {
-		parser := newParser(newLexer(test.template, "{{", "}}"), htmlEscape)
+		parser := newParser(newLexer(test.template, "{{", "}}", true), htmlEscape)
 		elems, err := parser.parse()
 		if err != nil {
 			t.Fatal(err)
@@ -110,8 +120,28 @@ func TestParserNegative(t *testing.T) {
 			"{{foo}",
 			`1:6 syntax error: unreachable code t_error:"unclosed tag"`,
 		},
+		{
+			"{{#test_value {{a}} b}}",
+			`1:21 syntax error: unexpected token t_error:"invalid test_value value token"`,
+		},
+		{
+			"{{#test_value {{a}} \"b}}",
+			`1:24 syntax error: unexpected token t_error:"failed to find close \" for test_value value token"`,
+		},
+		{
+			"{{#test_value {{a}} \"b\"}}",
+			`token "t_ident" not found`,
+		},
+		{
+			"{{#test_value a b}}",
+			`1:14 syntax error: unexpected token t_error:"Missing test_value identifier"`,
+		},
+		{
+			"{{#test_value {{a b\"}}",
+			`1:22 syntax error: unexpected token t_error:"invalid test_value value token"`,
+		},
 	} {
-		parser := newParser(newLexer(test.template, "{{", "}}"), htmlEscape)
+		parser := newParser(newLexer(test.template, "{{", "}}", true), htmlEscape)
 		_, err := parser.parse()
 		if err == nil || !strings.Contains(err.Error(), test.expErr) {
 			t.Errorf("expect error: %q, got %q", test.expErr, err)

--- a/parse_test.go
+++ b/parse_test.go
@@ -88,6 +88,16 @@ func TestParser(t *testing.T) {
 			},
 		},
 		{
+			"{{#test_value {{foo}} \"bar\"}}{{#a}}{{b}}{{/a}}{{/test_value}}",
+			[]node{
+				&testNode{"foo", "bar", []node{
+					&sectionNode{"a", false, []node{
+						&varNode{"b", htmlEscape},
+					}},
+				}},
+			},
+		},
+		{
 			"{{#list}}({{a}a}}){{/list}}",
 			[]node{
 				&sectionNode{"list", false, []node{


### PR DESCRIPTION
This adds:

`{{#test_value {{path}} "value"}}` as an option in mustache. 

Only if the value represented by `{{path}}` rendered as a string is equal to `value` will the contents of the section be rendered. 