### PR TITLE
Avoid rendering cycle in partials

### DIFF
--- a/mustache.go
+++ b/mustache.go
@@ -209,7 +209,16 @@ type partialNode struct {
 func (p *partialNode) render(t *Template, w *writer, c ...interface{}) error {
 	w.tag()
 	if template, ok := t.partials[p.name]; ok {
-		template.partials = t.partials
+
+		// We can avoid cycles by removing this node's template from the lookup
+		// before we render
+		template.partials = make(map[string]*Template)
+		for k, v := range t.partials {
+			if k != p.name {
+				template.partials[k] = v
+			}
+		}
+
 		err := template.render(w, c...)
 		if err != nil {
 			if !t.silentMiss {


### PR DESCRIPTION
We need to avoid self referential and non-self referential use cases or things will overflow. This avoids the condition by ensuring that when a partial renders itself, it removes itself from the available lookups downstream. If lookup failures are enabled, then the operation will fail. Otherwise, it will be a silent error.