### PR TITLE
feat: Add custom funcs to allow invoking mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,29 @@ context := map[string]interface{}{
 template.Render(os.Stdout, context)
 ```
 
+## Functions
+
+**note:** This is an extension to the mustache spec and library added by Observe Inc.
+
+Functions are additional functionality that a template can invoke to mutate a rendered section. The use caes is to allow escaping, encoding, alterations, or other manipulations of rendered text without applying it to the whole document. The impetus was the need to allow a URL to be properly formatted and encoded in a JSON document. The JSON encoding for the whole document applies, but the specific value must be treated special first. As another example, a custom function named `lowercase` could be added that would be invoked like:
+
+```mustache
+Your name in lowercase letters is:{{~lowercase}}{{name.first}} {{name.last}}{{/lowercase}}
+```
+
+Installing this customizing function is similar to partials, where you use an `Option` in the creation.
+
+```go
+func tolower(in string) (string, error) {
+    // TODO: implement a lowercase operation
+    return "", nil
+}
+
+tmpl := New(
+    CustomizeFunction("lowercase", tolower),
+)
+```
+
 # Tests
 
 Run `go test` as usual. If you want to run the spec tests against this package, make sure you've checked out the specs submodule. Otherwise spec tests will be skipped.

--- a/lex.go
+++ b/lex.go
@@ -29,43 +29,45 @@ type tokenType int
 const (
 	tokenError tokenType = iota // error occurred; value is text of error
 	tokenEOF
-	tokenIdentifier     // tag identifier: non-whitespace characters NOT containing closing delimiter
-	tokenLeftDelim      // {{ left action delimiter
-	tokenRightDelim     // }} right action delimiter
-	tokenText           // plain text
-	tokenComment        // {{! this is a comment and is ignored}}
-	tokenSectionStart   // {{#foo}} denotes a section start
-	tokenSectionInverse // {{^foo}} denotes an inverse section start
-	tokenSectionEnd     // {{/foo}} denotes the closing of a section
-	tokenRawStart       // { denotes the beginning of an unencoded identifier
-	tokenRawEnd         // } denotes the end of an unencoded identifier
-	tokenRawAlt         // {{&foo}} is an alternative way to define raw tags
-	tokenPartial        // {{>foo}} denotes a partial
-	tokenSetDelim       // {{={% %}=}} sets delimiters to {% and %}
-	tokenSetLeftDelim   // denotes a custom left delimiter
-	tokenSetRightDelim  // denotes a custom right delimiter
-	tokenTestValue      // denotes a test value section
+	tokenIdentifier      // tag identifier: non-whitespace characters NOT containing closing delimiter
+	tokenLeftDelim       // {{ left action delimiter
+	tokenRightDelim      // }} right action delimiter
+	tokenText            // plain text
+	tokenComment         // {{! this is a comment and is ignored}}
+	tokenSectionStart    // {{#foo}} denotes a section start
+	tokenSectionInverse  // {{^foo}} denotes an inverse section start
+	tokenSectionFunction // {{~foo}} denotes a functional section where the contents will be passed for additional processing
+	tokenSectionEnd      // {{/foo}} denotes the closing of a section
+	tokenRawStart        // { denotes the beginning of an unencoded identifier
+	tokenRawEnd          // } denotes the end of an unencoded identifier
+	tokenRawAlt          // {{&foo}} is an alternative way to define raw tags
+	tokenPartial         // {{>foo}} denotes a partial
+	tokenSetDelim        // {{={% %}=}} sets delimiters to {% and %}
+	tokenSetLeftDelim    // denotes a custom left delimiter
+	tokenSetRightDelim   // denotes a custom right delimiter
+	tokenTestValue       // denotes a test value section
 )
 
 // Make the types prettyprint.
 var tokenName = map[tokenType]string{
-	tokenError:          "t_error",
-	tokenEOF:            "t_eof",
-	tokenIdentifier:     "t_ident",
-	tokenLeftDelim:      "t_left_delim",
-	tokenRightDelim:     "t_right_delim",
-	tokenText:           "t_text",
-	tokenComment:        "t_comment",
-	tokenSectionStart:   "t_section_start",
-	tokenSectionInverse: "t_section_inverse",
-	tokenSectionEnd:     "t_section_end",
-	tokenRawStart:       "t_raw_start",
-	tokenRawEnd:         "t_raw_end",
-	tokenRawAlt:         "t_raw_alt",
-	tokenPartial:        "t_partial",
-	tokenSetDelim:       "t_set_delim",
-	tokenSetLeftDelim:   "t_set_left_delim",
-	tokenSetRightDelim:  "t_set_right_delim",
+	tokenError:           "t_error",
+	tokenEOF:             "t_eof",
+	tokenIdentifier:      "t_ident",
+	tokenLeftDelim:       "t_left_delim",
+	tokenRightDelim:      "t_right_delim",
+	tokenText:            "t_text",
+	tokenComment:         "t_comment",
+	tokenSectionStart:    "t_section_start",
+	tokenSectionInverse:  "t_section_inverse",
+	tokenSectionFunction: "t_section_function",
+	tokenSectionEnd:      "t_section_end",
+	tokenRawStart:        "t_raw_start",
+	tokenRawEnd:          "t_raw_end",
+	tokenRawAlt:          "t_raw_alt",
+	tokenPartial:         "t_partial",
+	tokenSetDelim:        "t_set_delim",
+	tokenSetLeftDelim:    "t_set_left_delim",
+	tokenSetRightDelim:   "t_set_right_delim",
 }
 
 // String satisfies the fmt.Stringer interface making it easier to print tokens.
@@ -336,6 +338,8 @@ func stateTag(l *lexer) stateFn {
 		l.emit(tokenSectionStart)
 	case r == '^':
 		l.emit(tokenSectionInverse)
+	case r == '~':
+		l.emit(tokenSectionFunction)
 	case r == '/':
 		l.emit(tokenSectionEnd)
 	case r == '&':

--- a/lookup.go
+++ b/lookup.go
@@ -24,6 +24,7 @@ func lookup(name string, context ...interface{}) (interface{}, bool) {
 		}
 		return nil, false
 	}
+
 	// Iterate over the context chain and try to match the name to a value.
 	for _, c := range context {
 		// Reflect on the value of the current context.

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -175,6 +175,35 @@ func TestInterpolationWithWhitespace(t *testing.T) {
 	}
 }
 
+func TestCustomFunctions(t *testing.T) {
+	input := strings.NewReader(`raw text {{~reverse}}txet erom{{/reverse}}`)
+	template := New(
+		CustomizeFunction("reverse", func(s string) (string, error) {
+			orig := []rune(s)
+			l := len(orig)
+			reversed := make([]rune, len(orig))
+			for i, j := 0, l-1; i < len(orig); i, j = i+1, j-1 {
+				reversed[j] = orig[i]
+			}
+			return string(reversed), nil
+		}),
+	)
+
+	err := template.Parse(input)
+	if err != nil {
+		t.Error(err)
+	}
+	var output bytes.Buffer
+	err = template.Render(&output, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	expected := `raw text more text`
+	if output.String() != expected {
+		t.Errorf("expected %q got %q", expected, output.String())
+	}
+}
+
 type templateTest struct {
 	template string
 	payload  interface{}

--- a/parse_test.go
+++ b/parse_test.go
@@ -107,6 +107,17 @@ func TestParser(t *testing.T) {
 				}},
 			},
 		},
+		{
+			"{{~customize}}blah blah{{/customize}}",
+			[]node{
+				&functionSectionNode{
+					"customize",
+					[]node{
+						textNode("blah blah"),
+					},
+				},
+			},
+		},
 	} {
 		parser := newParser(newLexer(test.template, "{{", "}}", true), htmlEscape)
 		elems, err := parser.parse()


### PR DESCRIPTION
This adds an Observe specific token `~` to act like a section and attempt a look in registered customize functions. It has an open and close part, just like a section, and everything within the section is passed to the function for rendering.

This was added to support an immediate need for url-encoding only a single part of a document, but likely will be used for additional formatting or encoding needs.

It's possible we could allow optional options/arguments in the lexing, but we don't need it right now. We aren't prevented from adding it in the future though.