### PR TITLE
fix: address panic when open tag encountered

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -34,6 +34,8 @@ func (p *parser) readt(t tokenType) ([]token, error) {
 		switch token.typ {
 		case tokenEOF:
 			return tokens, fmt.Errorf("token %q not found", t)
+		case tokenError:
+			return nil, p.errorf(token, "%s", token.val)
 		case t:
 			return tokens, nil
 		}


### PR DESCRIPTION
I checked the mainline and this is not fixed there. The root cause is that the token drain loop expects the EOF or error token to stop the draining, but the readt() didn't heandle the error case.