### PR TITLE
feat: Add customizer funcs with arguments

### DIFF
--- a/mustache_test.go
+++ b/mustache_test.go
@@ -204,6 +204,30 @@ func TestCustomFunctions(t *testing.T) {
 	}
 }
 
+func TestCustomFunctionsWithOptions(t *testing.T) {
+	input := strings.NewReader(`split: {{~split token="x"}}hexllxoxworxld{{/split}}`)
+	template := New(
+		CustomizeFunctionWithOptions("split", func(s string, opts map[string]string) (string, error) {
+			return strings.Join(strings.Split(s, opts["token"]), " "), nil
+		}),
+	)
+
+	err := template.Parse(input)
+	if err != nil {
+		t.Error(err)
+	}
+	var output bytes.Buffer
+	err = template.Render(&output, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("%+v", output)
+	expected := `split: he ll o wor ld`
+	if output.String() != expected {
+		t.Errorf("expected %q got %q", expected, output.String())
+	}
+}
+
 type templateTest struct {
 	template string
 	payload  interface{}

--- a/parse_test.go
+++ b/parse_test.go
@@ -112,6 +112,19 @@ func TestParser(t *testing.T) {
 			[]node{
 				&functionSectionNode{
 					"customize",
+					nil,
+					[]node{
+						textNode("blah blah"),
+					},
+				},
+			},
+		},
+		{ // so that we can do something like {{~lowercase locale="EN-US"}}...
+			`{{~customize opt1="value1" opt2="value2"}}blah blah{{/customize}}`,
+			[]node{
+				&functionSectionNode{
+					"customize",
+					map[string]string{"opt1": "value1", "opt2": "value2"},
 					[]node{
 						textNode("blah blah"),
 					},


### PR DESCRIPTION
The doc change shows an example. Another is
the more pressing need that I want to add something like `{{~truncate limit=100}}` so that we can allow the template to render a variable and then trunciate it maybe with an optional "..." argument kind of thing.