### PR TITLE
fix: improve error message for mismatched section tags

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -250,7 +250,7 @@ func (p *parser) parseSectionInternal(t token) ([]node, error) {
 	for {
 		read, err := p.readv(t)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to find closing tag for section %q opened at %d:%d", t.val, t.line, t.col)
 		}
 		tokens = append(tokens, read...)
 		if len(read) > 1 {

--- a/parse_test.go
+++ b/parse_test.go
@@ -164,7 +164,15 @@ func TestParserNegative(t *testing.T) {
 		},
 		{
 			"{{#test_value {{a}} \"b\"}}",
-			`token "t_ident" not found`,
+			`failed to find closing tag for section "test_value"`,
+		},
+		{
+			"{{#alert.severity.isCritical}}\n    test content\n    {{/alert.severity.isError}}",
+			`failed to find closing tag for section "alert.severity.isCritical"`,
+		},
+		{
+			"{{#foo}}hello{{/bar}}",
+			`failed to find closing tag for section "foo"`,
 		},
 		{
 			"{{#test_value a b}}",


### PR DESCRIPTION
When a template has mismatched or missing closing section tags, e.g.
```
{{#alert.severity.isCritical}}.
...
{{/alert.severity.isError}}
```
currently the parser produced a cryptic error `token "t_ident" not found`

This PR improves it with a clear message naming the section and its location:
`failed to find closing tag for section "alert.severity.isCritical" opened at 1:4`