### PR TITLE
feat: support quoted keys in dotted lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is built using lexing techniques described in the slides on [lexical scanning
 
 This package aims to cover 100% of the mustache specification tests, however by the time of this writing it is not complete. (It is missing some pieces around partials, lambdas, and inheritance.) 
 
-On the flip side it also has some alternate rules for escaping. Supports golang structs by field name, method, or tag. Has some extensions to the spec relating to array indexing, and a conditional value match. 
+On the flip side it also has some alternate rules for escaping. Supports golang structs by field name, method, or tag. Has some extensions to the spec relating to array indexing, quoted object keys, and a conditional value match. 
 
 For more information on mustache check the [official documentation](http://mustache.github.io/) and the [mustache spec](http://github.com/mustache/spec).
 
@@ -148,6 +148,43 @@ tmpl := New(
     CustomizeFunction("lowercase", tolower),
 )
 ```
+
+## Quoted keys
+
+**note:** This is an extension to the mustache spec added by Observe Inc.
+
+By default a dotted name is split on every `.`, so `{{ a.b.c }}` walks three levels. When a key itself contains a dot, wrap that segment in quotes so it is looked up as a single literal key instead of a nested path:
+
+```mustache
+{{ metrics."http.request.count" }}
+```
+
+Here `http.request.count` is one key under `metrics`, not a nested `http` → `request` → `count` path. Both double (`"…"`) and single (`'…'`) quotes are accepted and mean the same thing; pick whichever avoids escaping. Quoting is the only way to put a literal `.` in a key — dots inside quotes are never treated as separators.
+
+- **Escapes:** inside a quoted key only `\\` (a literal backslash) and the matching quote (`\"` in a double-quoted key, `\'` in a single-quoted key) are recognized. You do **not** need to escape dots. Any other backslash escape is a parse error.
+- **Empty key:** `""` and `''` are valid and address the empty-string key.
+- **Errors are reported at parse time.** A malformed quote (unterminated, bad escape, or trailing characters after the closing quote) makes `Parse`/`ParseString` return an error regardless of `SilentMiss` — `SilentMiss` only governs a *well-formed* lookup that finds nothing at render time.
+
+```Go
+t := mustache.New()
+t.ParseString(`{{ x."a.b" }}`)
+s, _ := t.RenderString(map[string]interface{}{
+    "x": map[string]interface{}{"a.b": "hello"},
+})
+// s == "hello"
+```
+
+Quoted keys may appear anywhere in a path — including nested segments and section tags:
+
+```mustache
+{{ config."feature.flags"."beta.mode" }}
+{{#items."a.b"}}{{name}}{{/items."a.b"}}
+```
+
+Two things to keep in mind:
+
+- A quoted **section** name must be written identically in the opening and closing tags, including quote style: `{{#a."b.c"}}…{{/a."b.c"}}`. A mismatch is reported as a missing closing tag.
+- A quoted key cannot contain the template's active closing delimiter. With the default delimiters, a `}}` inside a key truncates the tag and surfaces as an "unterminated quote" parse error; use custom `Delimiters` if a key must contain `}}`.
 
 # Tests
 

--- a/example_test.go
+++ b/example_test.go
@@ -139,3 +139,27 @@ func ExampleOption() {
 	// Output: Mustache
 	// Logic less templates with Mustache!
 }
+
+func ExampleTemplate_quotedKeys() {
+	template := New()
+	// Wrap a path segment in quotes to look up a key that itself contains dots
+	// as a single key, rather than descending into a nested path.
+	err := template.ParseString(`{{ metrics."http.request.count" }} requests to {{ metrics."http.route" }}`)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse template: %s\n", err)
+	}
+
+	context := map[string]interface{}{
+		"metrics": map[string]interface{}{
+			"http.request.count": 42,
+			"http.route":         "/api/orders",
+		},
+	}
+
+	output, err := template.RenderString(context)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to render template: %s\n", err)
+	}
+	fmt.Println(output)
+	// Output: 42 requests to /api/orders
+}

--- a/lex_test.go
+++ b/lex_test.go
@@ -81,6 +81,48 @@ func TestLexer(t *testing.T) {
 				{typ: tokenEOF},
 			},
 		},
+		{
+			// A quoted key is emitted as a single identifier token, quotes and
+			// interior dots included; surrounding whitespace is trimmed.
+			`foo {{ metrics."http.request.count" }}`,
+			[]token{
+				{typ: tokenText, val: "foo "},
+				{typ: tokenLeftDelim, val: "{{"},
+				{typ: tokenIdentifier, val: `metrics."http.request.count"`},
+				{typ: tokenRightDelim, val: "}}"},
+				{typ: tokenEOF},
+			},
+		},
+		{
+			// Single quotes and a quoted segment in the middle of a path.
+			`{{ fields.'service.name'.value }}`,
+			[]token{
+				{typ: tokenLeftDelim, val: "{{"},
+				{typ: tokenIdentifier, val: `fields.'service.name'.value`},
+				{typ: tokenRightDelim, val: "}}"},
+				{typ: tokenEOF},
+			},
+		},
+		{
+			// A single '}' inside a quoted key is not the closing delimiter.
+			`{{ x."a}b" }}`,
+			[]token{
+				{typ: tokenLeftDelim, val: "{{"},
+				{typ: tokenIdentifier, val: `x."a}b"`},
+				{typ: tokenRightDelim, val: "}}"},
+				{typ: tokenEOF},
+			},
+		},
+		{
+			// A backslash-escaped quote is carried through verbatim to the parser.
+			`{{ x."a\".b" }}`,
+			[]token{
+				{typ: tokenLeftDelim, val: "{{"},
+				{typ: tokenIdentifier, val: `x."a\".b"`},
+				{typ: tokenRightDelim, val: "}}"},
+				{typ: tokenEOF},
+			},
+		},
 	} {
 		var (
 			lexer = newLexer(test.template, "{{", "}}", true)

--- a/lookup.go
+++ b/lookup.go
@@ -4,56 +4,148 @@
 package mustache
 
 import (
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
 )
 
-// The lookup function searches for a property that matches name within the
-// context chain. We first start from the first item in the context chain which
-// is the most likely to have the value we're looking for. If not found, we'll
-// move up the chain and repeat.
-func lookup(name string, context ...interface{}) (interface{}, bool) {
-	// If the dot notation was used we split the word in two and perform two
-	// consecutive lookups. If the first one fails we return no value and a
-	// negative truth. Taken from github.com/hoisie/mustache.
-	if name != "." && strings.Contains(name, ".") {
-		parts := strings.SplitN(name, ".", 2)
-		if value, ok := lookup(parts[0], context...); ok {
-			return lookup(parts[1], value)
+// pathSegment is a single key within a dotted lookup path. quoted reports whether
+// the segment originated from a quoted key (e.g. "deployment.environment.name"). For
+// quoted segments the interior dots are literal and the "." whole-context shortcut
+// does not apply, so a quoted "." addresses a real key named ".".
+type pathSegment struct {
+	key    string
+	quoted bool
+}
+
+// parsePath splits a variable path into segments, honoring quoted key segments. A
+// segment beginning with a double or single quote is read up to its
+// matching closing quote; dots inside the quotes are literal and \\ and \" (or \')
+// are the only recognized escapes. Quotes that are not at the start of a segment are
+// ordinary characters. It returns an error for an unterminated quote, an invalid or
+// dangling backslash escape, or unexpected characters following a closing quote.
+//
+// A lone "." is returned as a single unquoted segment so that lookup can resolve it
+// to the whole current context (the {{.}} tag).
+func parsePath(raw string) ([]pathSegment, error) {
+	if raw == "." {
+		return []pathSegment{{key: "."}}, nil
+	}
+	var segments []pathSegment
+	i, n := 0, len(raw)
+	for {
+		var seg pathSegment
+		if i < n && (raw[i] == '"' || raw[i] == '\'') {
+			key, next, err := parseQuotedSegment(raw, i)
+			if err != nil {
+				return nil, err
+			}
+			seg = pathSegment{key: key, quoted: true}
+			i = next
+			if i < n && raw[i] != '.' {
+				return nil, fmt.Errorf("unexpected %q after closing quote in path %q", string(raw[i]), raw)
+			}
+		} else {
+			// Unquoted segment: everything up to the next dot is a literal key; any
+			// quote characters here are ordinary runes.
+			start := i
+			for i < n && raw[i] != '.' {
+				i++
+			}
+			seg = pathSegment{key: raw[start:i]}
 		}
+		segments = append(segments, seg)
+		if i == n {
+			break
+		}
+		i++ // consume the separator '.'
+		if i == n {
+			segments = append(segments, pathSegment{}) // trailing dot -> empty final segment
+			break
+		}
+	}
+	return segments, nil
+}
+
+// parseQuotedSegment reads a quoted key that begins at raw[start] (a quote rune) and
+// returns the unescaped key together with the index just past the closing quote.
+func parseQuotedSegment(raw string, start int) (string, int, error) {
+	quote := raw[start]
+	var b strings.Builder
+	for i := start + 1; i < len(raw); i++ {
+		switch c := raw[i]; c {
+		case quote:
+			return b.String(), i + 1, nil
+		case '\\':
+			if i+1 >= len(raw) {
+				return "", 0, fmt.Errorf("dangling escape in path %q", raw)
+			}
+			esc := raw[i+1]
+			if esc != '\\' && esc != quote {
+				return "", 0, fmt.Errorf("invalid escape \\%s in path %q", string(esc), raw)
+			}
+			b.WriteByte(esc)
+			i++ // skip the escaped character
+		default:
+			b.WriteByte(c)
+		}
+	}
+	return "", 0, fmt.Errorf("unterminated quote in path %q", raw)
+}
+
+// lookupPath resolves a pre-parsed path against the context chain. The first segment
+// is searched across the whole chain (most-specific context first); each subsequent
+// segment drills into the value found by the previous one. A falsy intermediate value
+// stops the walk (matching dotted-lookup behavior), but the final segment's value and
+// truth are returned as-is, so a found-but-falsy value (a nil pointer, 0, false, "")
+// is still returned.
+func lookupPath(path []pathSegment, context ...interface{}) (interface{}, bool) {
+	if len(path) == 0 {
 		return nil, false
 	}
+	value, ok := resolveSegment(path[0], context...)
+	for _, seg := range path[1:] {
+		if !ok {
+			return nil, false
+		}
+		value, ok = resolveSegment(seg, value)
+	}
+	return value, ok
+}
 
-	// Iterate over the context chain and try to match the name to a value.
+// resolveSegment searches the context chain for a single path segment. It mirrors the
+// per-context resolution used for dotted names: maps, structs, and arrays/slices are
+// probed in turn, and an unquoted "." returns the whole context as-is.
+func resolveSegment(seg pathSegment, context ...interface{}) (interface{}, bool) {
 	for _, c := range context {
-		// Reflect on the value of the current context.
 		reflectValue := reflect.ValueOf(c)
-		// If the name is ".", we should return the whole context as-is.
-		if name == "." {
+		// If the segment is an unquoted ".", return the whole context as-is. A quoted
+		// "." is a literal key and falls through to the normal resolution below.
+		if !seg.quoted && seg.key == "." {
 			return c, truth(reflectValue)
 		}
 		switch reflectValue.Kind() {
 		// If the current context is a map, we'll look for a key in that map
-		// that matches the name.
+		// that matches the segment.
 		case reflect.Map:
-			val, ok, found := lookup_map(name, reflectValue)
+			val, ok, found := lookup_map(seg.key, reflectValue)
 			if found {
 				return val, ok
 			}
 
 		// If the current context is a struct, we'll look for a property in that
-		// struct that matches the name.
+		// struct that matches the segment.
 		case reflect.Struct:
-			val, ok, found := lookup_struct(name, reflectValue)
+			val, ok, found := lookup_struct(seg.key, reflectValue)
 			if found {
 				return val, ok
 			}
 
-		// If the current context is an array or slice, we'll try to find the current
-		// name as an index in the context.
+		// If the current context is an array or slice, we'll try to find the segment
+		// as an index in the context.
 		case reflect.Array, reflect.Slice:
-			val, ok, found := lookup_array(name, reflectValue)
+			val, ok, found := lookup_array(seg.key, reflectValue)
 			if found {
 				return val, ok
 			}

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -104,7 +104,11 @@ func TestSimpleLookup(t *testing.T) {
 		},
 	} {
 		for _, assertion := range test.assertions {
-			value, truth := lookup(assertion.name, test.context)
+			path, err := parsePath(assertion.name)
+			if err != nil {
+				t.Fatalf("parsePath(%q): %v", assertion.name, err)
+			}
+			value, truth := lookupPath(path, test.context)
 			if value != assertion.value {
 				t.Errorf("Unexpected value %v,%T != %v,%T", value, value, assertion.value, assertion.value)
 			}
@@ -113,6 +117,16 @@ func TestSimpleLookup(t *testing.T) {
 			}
 		}
 	}
+}
+
+// mustPath parses raw into path segments for use in expected test trees,
+// panicking on a malformed path.
+func mustPath(raw string) []pathSegment {
+	segs, err := parsePath(raw)
+	if err != nil {
+		panic(err)
+	}
+	return segs
 }
 
 func TestTruth(t *testing.T) {

--- a/mustache.go
+++ b/mustache.go
@@ -93,12 +93,13 @@ func (e escapeType) String() string {
 // by a variable that exists within c.
 type varNode struct {
 	name   string
+	path   []pathSegment
 	escape escapeType
 }
 
 func (n *varNode) render(t *Template, w *writer, c ...interface{}) error {
 	w.text()
-	v, _ := lookup(n.name, c...)
+	v, _ := lookupPath(n.path, c...)
 	// If the value is present but 'falsy', such as a false bool, or a zero int,
 	// we still want to render that value.
 	if v != nil {
@@ -116,6 +117,7 @@ func (n *varNode) String() string {
 // elements while passing along its context along with the global context.
 type sectionNode struct {
 	name     string
+	path     []pathSegment
 	inverted bool
 	elems    []node
 }
@@ -135,7 +137,7 @@ func (n *sectionNode) render(t *Template, w *writer, c ...interface{}) error {
 		}
 	}
 
-	v, ok := lookup(n.name, c...)
+	v, ok := lookupPath(n.path, c...)
 	if ok != n.inverted {
 		r := reflect.ValueOf(v)
 		switch r.Kind() {
@@ -210,16 +212,16 @@ func (n *functionSectionNode) render(t *Template, w *writer, c ...interface{}) e
 // The testNode type is a complex node which recursively renders its child
 // elements while passing along its context along with the global context.
 type testNode struct {
-	testIdent string
-	testVal   string
-	elems     []node
+	testIdentPath []pathSegment
+	testVal       string
+	elems         []node
 }
 
 func (n *testNode) render(t *Template, w *writer, c ...interface{}) error {
 	w.tag()
 	defer w.tag()
 	errs := ErrorSlice{}
-	v, _ := lookup(n.testIdent, c...)
+	v, _ := lookupPath(n.testIdentPath, c...)
 	if v != nil {
 		vs := strings.Builder{}
 		print(&vs, v, noEscape)

--- a/mustache_test.go
+++ b/mustache_test.go
@@ -49,14 +49,14 @@ func TestParseTree(t *testing.T) {
 	template := New()
 	template.elems = []node{
 		textNode("Lorem ipsum dolor sit "),
-		&varNode{"foo", noEscape},
+		&varNode{"foo", mustPath("foo"), noEscape},
 		textNode(", "),
-		&sectionNode{"bar", false, []node{
-			&varNode{"baz", htmlEscape},
+		&sectionNode{"bar", mustPath("bar"), false, []node{
+			&varNode{"baz", mustPath("baz"), htmlEscape},
 			textNode(" adipiscing"),
 		}},
 		textNode(" elit. Proin commodo viverra elit "),
-		&varNode{"zer", noEscape},
+		&varNode{"zer", mustPath("zer"), noEscape},
 		textNode("."),
 	}
 	data := map[string]interface{}{
@@ -310,5 +310,105 @@ func TestPartialsCannotCycle(t *testing.T) {
 	expected := `I am the outer.I am the inner.`
 	if output.String() != expected {
 		t.Errorf("expected %q got %q", expected, output.String())
+	}
+}
+
+func TestQuotedKeyTemplates(t *testing.T) {
+	for _, test := range []templateTest{
+		{ // double-quoted key containing dots
+			`{{ metrics."http.request.count" }}`,
+			map[string]interface{}{"metrics": map[string]interface{}{"http.request.count": 42}},
+			`42`,
+		},
+		{ // single quotes are equivalent
+			`{{ metrics.'http.request.count' }}`,
+			map[string]interface{}{"metrics": map[string]interface{}{"http.request.count": 42}},
+			`42`,
+		},
+		{ // non-terminal quoted segment, then a normal key
+			`{{ a."b.c".d }}`,
+			map[string]interface{}{"a": map[string]interface{}{"b.c": map[string]interface{}{"d": "X"}}},
+			`X`,
+		},
+		{ // backslash-escaped quote inside a key
+			`{{ files."a\".b" }}`,
+			map[string]interface{}{"files": map[string]interface{}{`a".b`: "ok"}},
+			`ok`,
+		},
+		{ // HTML escaping still applies to the resolved value
+			`{{ x."a.b" }}`,
+			map[string]interface{}{"x": map[string]interface{}{"a.b": "<v>"}},
+			`&lt;v&gt;`,
+		},
+		{ // triple-brace leaves the value raw
+			`{{{ x."a.b" }}}`,
+			map[string]interface{}{"x": map[string]interface{}{"a.b": "<v>"}},
+			`<v>`,
+		},
+		{ // empty quoted key addresses the empty-string key
+			`{{ m."" }}`,
+			map[string]interface{}{"m": map[string]interface{}{"": "E"}},
+			`E`,
+		},
+		{ // a quoted "." is a literal key, not the whole-context shortcut
+			`{{ obj."." }}`,
+			map[string]interface{}{"obj": map[string]interface{}{".": "dot"}},
+			`dot`,
+		},
+		{ // a section whose name is a quoted key, iterating a slice
+			`{{#groups."a.b"}}{{name}} {{/groups."a.b"}}`,
+			map[string]interface{}{"groups": map[string]interface{}{"a.b": []interface{}{
+				map[string]interface{}{"name": "x"},
+				map[string]interface{}{"name": "y"},
+			}}},
+			`x y `,
+		},
+	} {
+		template := New(SilentMiss(false))
+		if err := template.ParseString(test.template); err != nil {
+			t.Errorf("parse %q: %v", test.template, err)
+			continue
+		}
+		out, err := template.RenderString(test.payload)
+		if err != nil {
+			t.Errorf("render %q: %v", test.template, err)
+			continue
+		}
+		if out != test.expect {
+			t.Errorf("template %q: expected %q got %q", test.template, test.expect, out)
+		}
+	}
+}
+
+func TestRenderJSONBodyWithQuotedKeys(t *testing.T) {
+	// A realistic use: build a JSON payload whose values come from a map keyed by
+	// dotted field names, each holding a nested "value". It mixes quoted (dotted)
+	// and unquoted keys; SilentMiss(false) makes any missed lookup fail the test.
+	body := `{"service":"{{ fields."service.name".value }}",` +
+		`"env":"{{ fields."deployment.environment.name".value }}",` +
+		`"status":{{ fields."http.response.status_code".value }},` +
+		`"seq":{{ fields.seqNum.value }},"ok":true}`
+
+	template := New(SilentMiss(false))
+	if err := template.ParseString(body); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	context := map[string]interface{}{
+		"fields": map[string]interface{}{
+			"service.name":                map[string]interface{}{"value": "checkout"},
+			"deployment.environment.name": map[string]interface{}{"value": "production"},
+			"http.response.status_code":   map[string]interface{}{"value": 500},
+			"seqNum":                      map[string]interface{}{"value": 7},
+		},
+	}
+
+	got, err := template.RenderString(context)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	want := `{"service":"checkout","env":"production","status":500,"seq":7,"ok":true}`
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
 	}
 }

--- a/parse.go
+++ b/parse.go
@@ -138,7 +138,11 @@ func (p *parser) parseRawTag() (node, error) {
 	if next := p.read(); next.typ != tokenRightDelim {
 		return nil, p.errorf(t, "unexpected token %s", t)
 	}
-	return &varNode{name: t.val, escape: noEscape}, nil
+	path, err := parsePath(t.val)
+	if err != nil {
+		return nil, p.errorf(t, "%s", err)
+	}
+	return &varNode{name: t.val, path: path, escape: noEscape}, nil
 }
 
 // parseVar parses a simple variable tag. It is assumed that the read from the
@@ -147,7 +151,11 @@ func (p *parser) parseVar(ident token, escape escapeType) (node, error) {
 	if t := p.read(); t.typ != tokenRightDelim {
 		return nil, p.errorf(t, "unexpected token %s", t)
 	}
-	return &varNode{name: ident.val, escape: escape}, nil
+	path, err := parsePath(ident.val)
+	if err != nil {
+		return nil, p.errorf(ident, "%s", err)
+	}
+	return &varNode{name: ident.val, path: path, escape: escape}, nil
 }
 
 // parseComment parses a comment block. It is assumed that the next read should
@@ -177,6 +185,11 @@ func (p *parser) parseSection(inverse bool) (node, error) {
 		return nil, p.errorf(t, "unexpected token %s", t)
 	}
 
+	path, err := parsePath(t.val)
+	if err != nil {
+		return nil, p.errorf(t, "%s", err)
+	}
+
 	nodes, err := p.parseSectionInternal(t)
 	if err != nil {
 		return nil, err
@@ -184,6 +197,7 @@ func (p *parser) parseSection(inverse bool) (node, error) {
 
 	section := &sectionNode{
 		name:     t.val,
+		path:     path,
 		inverted: inverse,
 		elems:    nodes,
 	}
@@ -250,7 +264,11 @@ func (p *parser) parseSectionInternal(t token) ([]node, error) {
 	for {
 		read, err := p.readv(t)
 		if err != nil {
-			return nil, fmt.Errorf("failed to find closing tag for section %q opened at %d:%d", t.val, t.line, t.col)
+			msg := fmt.Sprintf("failed to find closing tag for section %q opened at %d:%d", t.val, t.line, t.col)
+			if strings.ContainsAny(t.val, `"'`) {
+				msg += " (quoted section names must match the opening tag exactly, including quote style)"
+			}
+			return nil, fmt.Errorf("%s", msg)
 		}
 		tokens = append(tokens, read...)
 		if len(read) > 1 {
@@ -300,15 +318,20 @@ func (p *parser) parseTest() (node, error) {
 		return nil, p.errorf(v, "unexpected token %s", v)
 	}
 
+	testIdentPath, err := parsePath(i.val)
+	if err != nil {
+		return nil, p.errorf(i, "%s", err)
+	}
+
 	nodes, err := p.parseSectionInternal(t)
 	if err != nil {
 		return nil, err
 	}
 
 	section := &testNode{
-		testIdent: i.val,
-		testVal:   v.val,
-		elems:     nodes,
+		testIdentPath: testIdentPath,
+		testVal:       v.val,
+		elems:         nodes,
 	}
 	return section, nil
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -16,9 +16,9 @@ func TestParser(t *testing.T) {
 		{
 			"{{#foo}}\n\t{{#foo}}hello nested{{/foo}}{{/foo}}",
 			[]node{
-				&sectionNode{"foo", false, []node{
+				&sectionNode{"foo", mustPath("foo"), false, []node{
 					textNode("\n\t"),
-					&sectionNode{"foo", false, []node{
+					&sectionNode{"foo", mustPath("foo"), false, []node{
 						textNode("hello nested"),
 					}},
 				}},
@@ -28,9 +28,9 @@ func TestParser(t *testing.T) {
 			"\nfoo {{bar}} {{#alex}}\r\n\tbaz\n{{/alex}} {{!foo}}",
 			[]node{
 				textNode("\nfoo "),
-				&varNode{"bar", htmlEscape},
+				&varNode{"bar", mustPath("bar"), htmlEscape},
 				textNode(" "),
-				&sectionNode{"alex", false, []node{
+				&sectionNode{"alex", mustPath("alex"), false, []node{
 					textNode("\r\n\tbaz\n"),
 				}},
 				textNode(" "),
@@ -41,7 +41,7 @@ func TestParser(t *testing.T) {
 			"this will{{^foo}}not{{/foo}} be rendered",
 			[]node{
 				textNode("this will"),
-				&sectionNode{"foo", true, []node{
+				&sectionNode{"foo", mustPath("foo"), true, []node{
 					textNode("not"),
 				}},
 				textNode(" be rendered"),
@@ -50,9 +50,9 @@ func TestParser(t *testing.T) {
 		{
 			"{{#list}}({{.}}){{/list}}",
 			[]node{
-				&sectionNode{"list", false, []node{
+				&sectionNode{"list", mustPath("list"), false, []node{
 					textNode("("),
-					&varNode{".", htmlEscape},
+					&varNode{".", mustPath("."), htmlEscape},
 					textNode(")"),
 				}},
 			},
@@ -60,9 +60,9 @@ func TestParser(t *testing.T) {
 		{
 			"{{#*}}({{.}}){{/*}}",
 			[]node{
-				&sectionNode{"*", false, []node{
+				&sectionNode{"*", mustPath("*"), false, []node{
 					textNode("("),
-					&varNode{".", htmlEscape},
+					&varNode{".", mustPath("."), htmlEscape},
 					textNode(")"),
 				}},
 			},
@@ -70,9 +70,9 @@ func TestParser(t *testing.T) {
 		{
 			"{{#list}}({{*}}){{/list}}",
 			[]node{
-				&sectionNode{"list", false, []node{
+				&sectionNode{"list", mustPath("list"), false, []node{
 					textNode("("),
-					&varNode{"*", htmlEscape},
+					&varNode{"*", mustPath("*"), htmlEscape},
 					textNode(")"),
 				}},
 			},
@@ -80,9 +80,9 @@ func TestParser(t *testing.T) {
 		{
 			"{{#test_value {{foo}} \"bar\"}}({{a}a}}){{/test_value}}",
 			[]node{
-				&testNode{"foo", "bar", []node{
+				&testNode{mustPath("foo"), "bar", []node{
 					textNode("("),
-					&varNode{"a}a", htmlEscape},
+					&varNode{"a}a", mustPath("a}a"), htmlEscape},
 					textNode(")"),
 				}},
 			},
@@ -90,9 +90,9 @@ func TestParser(t *testing.T) {
 		{
 			"{{#test_value {{foo}} \"bar\"}}{{#a}}{{b}}{{/a}}{{/test_value}}",
 			[]node{
-				&testNode{"foo", "bar", []node{
-					&sectionNode{"a", false, []node{
-						&varNode{"b", htmlEscape},
+				&testNode{mustPath("foo"), "bar", []node{
+					&sectionNode{"a", mustPath("a"), false, []node{
+						&varNode{"b", mustPath("b"), htmlEscape},
 					}},
 				}},
 			},
@@ -100,9 +100,9 @@ func TestParser(t *testing.T) {
 		{
 			"{{#list}}({{a}a}}){{/list}}",
 			[]node{
-				&sectionNode{"list", false, []node{
+				&sectionNode{"list", mustPath("list"), false, []node{
 					textNode("("),
-					&varNode{"a}a", htmlEscape},
+					&varNode{"a}a", mustPath("a}a"), htmlEscape},
 					textNode(")"),
 				}},
 			},
@@ -129,6 +129,26 @@ func TestParser(t *testing.T) {
 						textNode("blah blah"),
 					},
 				},
+			},
+		},
+		{
+			`{{ metrics."http.request.count" }}`,
+			[]node{
+				&varNode{`metrics."http.request.count"`, mustPath(`metrics."http.request.count"`), htmlEscape},
+			},
+		},
+		{
+			`{{ fields.'service.name'.value }}`,
+			[]node{
+				&varNode{`fields.'service.name'.value`, mustPath(`fields.'service.name'.value`), htmlEscape},
+			},
+		},
+		{
+			`{{#config."feature.flags"}}{{enabled}}{{/config."feature.flags"}}`,
+			[]node{
+				&sectionNode{`config."feature.flags"`, mustPath(`config."feature.flags"`), false, []node{
+					&varNode{"enabled", mustPath("enabled"), htmlEscape},
+				}},
 			},
 		},
 	} {
@@ -181,6 +201,26 @@ func TestParserNegative(t *testing.T) {
 		{
 			"{{#test_value {{a b\"}}",
 			`1:22 syntax error: unexpected token t_error:"invalid test_value value token"`,
+		},
+		{
+			`{{ "foo }}`,
+			`unterminated quote`,
+		},
+		{
+			`{{ x."a\q" }}`,
+			`invalid escape`,
+		},
+		{
+			`{{{ x."a }}}`,
+			`unterminated quote`,
+		},
+		{
+			`{{ x."a"b }}`,
+			`unexpected`,
+		},
+		{
+			`{{#a."b"}}x{{/a.'b'}}`,
+			`failed to find closing tag`,
 		},
 	} {
 		parser := newParser(newLexer(test.template, "{{", "}}", true), htmlEscape)

--- a/quoted_test.go
+++ b/quoted_test.go
@@ -1,0 +1,450 @@
+// Copyright (c) 2014 Alex Kalyvitis
+
+package mustache
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestParsePath exercises the quote-aware path splitter directly: barewords, both
+// quote styles, escapes, empty keys, unicode, and every malformed-quote error.
+func TestParsePath(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		raw     string
+		want    []pathSegment
+		wantErr string // non-empty => parsePath must return an error containing this
+	}{
+		// Barewords (unchanged behavior).
+		{"single", "x", []pathSegment{{"x", false}}, ""},
+		{"dotted", "a.b", []pathSegment{{"a", false}, {"b", false}}, ""},
+		{"dotted3", "a.b.c", []pathSegment{{"a", false}, {"b", false}, {"c", false}}, ""},
+		{"empty middle", "a..b", []pathSegment{{"a", false}, {"", false}, {"b", false}}, ""},
+		{"leading dot", ".x", []pathSegment{{"", false}, {"x", false}}, ""},
+		{"trailing dot", "a.", []pathSegment{{"a", false}, {"", false}}, ""},
+		{"lone dot", ".", []pathSegment{{".", false}}, ""},
+
+		// Double-quoted.
+		{"dq single", `"a"`, []pathSegment{{"a", true}}, ""},
+		{"dq dotted key", `x."a.b"`, []pathSegment{{"x", false}, {"a.b", true}}, ""},
+		{"dq all dots", `"a.b.c.d"`, []pathSegment{{"a.b.c.d", true}}, ""},
+		{"dq then bareword", `"a.b".c`, []pathSegment{{"a.b", true}, {"c", false}}, ""},
+		{"dq non-terminal", `a."b.c".d`, []pathSegment{{"a", false}, {"b.c", true}, {"d", false}}, ""},
+
+		// Single-quoted (interchangeable with double quotes).
+		{"sq single", `'a'`, []pathSegment{{"a", true}}, ""},
+		{"sq dotted key", `x.'a.b'`, []pathSegment{{"x", false}, {"a.b", true}}, ""},
+		{"sq then bareword", `'a.b'.c`, []pathSegment{{"a.b", true}, {"c", false}}, ""},
+		{"sq non-terminal", `a.'b.c'.d`, []pathSegment{{"a", false}, {"b.c", true}, {"d", false}}, ""},
+
+		// Mixed styles in one path.
+		{"mixed", `'a'."b".'c'`, []pathSegment{{"a", true}, {"b", true}, {"c", true}}, ""},
+
+		// Empty quoted keys are legal (empty-string key).
+		{"dq empty", `""`, []pathSegment{{"", true}}, ""},
+		{"sq empty", `''`, []pathSegment{{"", true}}, ""},
+		{"dq empty nested", `x.""`, []pathSegment{{"x", false}, {"", true}}, ""},
+		{"sq empty middle", `a.''.b`, []pathSegment{{"a", false}, {"", true}, {"b", false}}, ""},
+
+		// Escapes inside double quotes: \\ and \".
+		{"dq esc quote", `"a\"b"`, []pathSegment{{`a"b`, true}}, ""},
+		{"dq esc quote dot", `"a\".b"`, []pathSegment{{`a".b`, true}}, ""},
+		{"dq esc backslash", `"a\\b"`, []pathSegment{{`a\b`, true}}, ""},
+		{"dq lone backslash", `"\\"`, []pathSegment{{`\`, true}}, ""},
+
+		// Escapes inside single quotes: \\ and \'.
+		{"sq esc quote", `'a\'b'`, []pathSegment{{`a'b`, true}}, ""},
+		{"sq esc backslash", `'a\\b'`, []pathSegment{{`a\b`, true}}, ""},
+
+		// The other quote char is an ordinary literal inside a quoted key.
+		{"dq contains sq", `"a'b"`, []pathSegment{{`a'b`, true}}, ""},
+		{"sq contains dq", `'a"b'`, []pathSegment{{`a"b`, true}}, ""},
+
+		// Whitespace inside quotes is preserved.
+		{"interior space", `"a b"`, []pathSegment{{"a b", true}}, ""},
+		{"trailing space", `"a "`, []pathSegment{{"a ", true}}, ""},
+		{"leading space", `"  a"`, []pathSegment{{"  a", true}}, ""},
+		{"lone space", `" "`, []pathSegment{{" ", true}}, ""},
+
+		// Unicode / multibyte keys (byte-scan safety for '.' and quotes).
+		{"unicode", `"café.au"`, []pathSegment{{"café.au", true}}, ""},
+		{"cjk", `"日本.語"`, []pathSegment{{"日本.語", true}}, ""},
+
+		// A quoted "." is a literal key, not the whole-context shortcut.
+		{"dq dot key", `"."`, []pathSegment{{".", true}}, ""},
+		{"sq dot key", `'.'`, []pathSegment{{".", true}}, ""},
+
+		// Quoted segment followed by a trailing dot (empty final segment).
+		{"dq trailing dot", `"a".`, []pathSegment{{"a", true}, {"", false}}, ""},
+		{"sq trailing dot", `'a'.`, []pathSegment{{"a", true}, {"", false}}, ""},
+		// A quote that is not at a segment start is an ordinary character.
+		{"quote mid bareword", `a"b`, []pathSegment{{`a"b`, false}}, ""},
+
+		// Errors: unterminated quotes.
+		{"unterminated dq", `"foo`, nil, "unterminated quote"},
+		{"unterminated sq", `'foo`, nil, "unterminated quote"},
+		{"unterminated nested", `x."foo`, nil, "unterminated quote"},
+		{"unterminated with dot", `"foo.bar`, nil, "unterminated quote"},
+		// Errors: dangling / unknown escapes.
+		{"dangling escape", `"a\`, nil, "dangling escape"},
+		{"unknown escape dq", `"a\q"`, nil, "invalid escape"},
+		{"unknown escape sq", `'a\z'`, nil, "invalid escape"},
+		{"dq escape sq invalid", `"a\'"`, nil, "invalid escape"},
+		{"sq escape dq invalid", `'a\"'`, nil, "invalid escape"},
+		// Errors: junk after a closing quote.
+		{"junk after dq", `"a"b`, nil, "unexpected"},
+		{"junk after sq", `'a'b`, nil, "unexpected"},
+		{"adjacent quotes", `"a""b"`, nil, "unexpected"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parsePath(test.raw)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("parsePath(%q): want error containing %q, got %v", test.raw, test.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parsePath(%q): unexpected error %v", test.raw, err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("parsePath(%q) = %#v, want %#v", test.raw, got, test.want)
+			}
+		})
+	}
+}
+
+// TestLookupQuoted exercises lookupPath over parsed quoted paths, including the
+// bug-prone cases: non-terminal quoted segments, quoted "." vs whole-context,
+// dotted struct tags, empty keys, and found-but-falsy values.
+func TestLookupQuoted(t *testing.T) {
+	type tagged struct {
+		Field string `mustache:"a.b"`
+	}
+	for _, test := range []struct {
+		name      string
+		path      string
+		context   interface{}
+		wantValue interface{}
+		wantTruth bool
+	}{
+		{
+			"double-quoted dotted key",
+			`"a.b"`,
+			map[string]interface{}{"a.b": "v"},
+			"v", true,
+		},
+		{
+			"single-quoted dotted key",
+			`'a.b'`,
+			map[string]interface{}{"a.b": "v"},
+			"v", true,
+		},
+		{
+			"nested quoted terminal",
+			`attributes."deployment.environment.name"`,
+			map[string]interface{}{"attributes": map[string]interface{}{
+				"deployment.environment.name": "prod"}},
+			"prod", true,
+		},
+		{
+			"non-terminal quoted (double)",
+			`a."b.c".d`,
+			map[string]interface{}{"a": map[string]interface{}{
+				"b.c": map[string]interface{}{"d": "X"}}},
+			"X", true,
+		},
+		{
+			"non-terminal quoted (single)",
+			`a.'b.c'.d`,
+			map[string]interface{}{"a": map[string]interface{}{
+				"b.c": map[string]interface{}{"d": "X"}}},
+			"X", true,
+		},
+		{
+			"quoted dot is a literal key",
+			`"."`,
+			map[string]interface{}{".": "dot-key"},
+			"dot-key", true,
+		},
+		{
+			"bare dot is whole context",
+			`.`,
+			"whole",
+			"whole", true,
+		},
+		{
+			"dotted struct tag via quoted key",
+			`"a.b"`,
+			tagged{Field: "tagged"},
+			"tagged", true,
+		},
+		{
+			"empty quoted key",
+			`""`,
+			map[string]interface{}{"": "empty-key"},
+			"empty-key", true,
+		},
+		{
+			"found but falsy int",
+			`n`,
+			map[string]interface{}{"n": 0},
+			0, false,
+		},
+		{
+			"found but falsy bool",
+			`b`,
+			map[string]interface{}{"b": false},
+			false, false,
+		},
+		{
+			"missing quoted key",
+			`x."a.b"`,
+			map[string]interface{}{"x": map[string]interface{}{"other": 1}},
+			nil, false,
+		},
+		{
+			"found but falsy empty string",
+			`s`,
+			map[string]interface{}{"s": ""},
+			"", false,
+		},
+		{
+			"falsy intermediate stops walk",
+			`a.b.c`,
+			map[string]interface{}{"a": map[string]interface{}{"b": 0}},
+			nil, false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			value, truth := lookupPath(mustPath(test.path), test.context)
+			if !reflect.DeepEqual(value, test.wantValue) {
+				t.Errorf("lookupPath(%q) value = %#v, want %#v", test.path, value, test.wantValue)
+			}
+			if truth != test.wantTruth {
+				t.Errorf("lookupPath(%q) truth = %t, want %t", test.path, truth, test.wantTruth)
+			}
+		})
+	}
+}
+
+// TestQuotedRender is the end-to-end coverage: templates with quoted keys rendered
+// against real contexts.
+func TestQuotedRender(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		template string
+		context  interface{}
+		want     string
+		options  []Option
+	}{
+		{
+			"double quotes",
+			`{{ x."a.b" }}`,
+			map[string]interface{}{"x": map[string]interface{}{"a.b": "v"}},
+			"v", nil,
+		},
+		{
+			"single quotes",
+			`{{ x.'a.b' }}`,
+			map[string]interface{}{"x": map[string]interface{}{"a.b": "v"}},
+			"v", nil,
+		},
+		{
+			"nested dotted key",
+			`{{ attributes."deployment.environment.name" }}`,
+			map[string]interface{}{"attributes": map[string]interface{}{
+				"deployment.environment.name": "prod"}},
+			"prod", nil,
+		},
+		{
+			"interior space",
+			`{{ x."a b" }}`,
+			map[string]interface{}{"x": map[string]interface{}{"a b": "sp"}},
+			"sp", nil,
+		},
+		{
+			"escaped quote in key",
+			`{{ x."a\".b" }}`,
+			map[string]interface{}{"x": map[string]interface{}{`a".b`: "esc"}},
+			"esc", nil,
+		},
+		{
+			"non-terminal quoted segment",
+			`{{ a."b.c".d }}`,
+			map[string]interface{}{"a": map[string]interface{}{
+				"b.c": map[string]interface{}{"d": "X"}}},
+			"X", nil,
+		},
+		{
+			"html escaped by default",
+			`{{ x."a.b" }}`,
+			map[string]interface{}{"x": map[string]interface{}{"a.b": "<b>"}},
+			"&lt;b&gt;", nil,
+		},
+		{
+			"triple brace is raw",
+			`{{{ x."a.b" }}}`,
+			map[string]interface{}{"x": map[string]interface{}{"a.b": "<b>"}},
+			"<b>", nil,
+		},
+		{
+			"ampersand raw alt",
+			`{{& x."a.b" }}`,
+			map[string]interface{}{"x": map[string]interface{}{"a.b": "<b>"}},
+			"<b>", nil,
+		},
+		{
+			"empty quoted key",
+			`{{ x."" }}`,
+			map[string]interface{}{"x": map[string]interface{}{"": "E"}},
+			"E", nil,
+		},
+		{
+			"back-compat: unquoted-inside resolves stripped key",
+			`{{ x."a" }}`,
+			map[string]interface{}{"x": map[string]interface{}{"a": "plain", `"a"`: "old"}},
+			"plain", nil,
+		},
+		{
+			"section with quoted name",
+			`{{#a."b.c"}}{{d}}{{/a."b.c"}}`,
+			map[string]interface{}{"a": map[string]interface{}{
+				"b.c": map[string]interface{}{"d": "in"}}},
+			"in", nil,
+		},
+		{
+			"inverse section with quoted name",
+			`{{^a."b.c"}}no{{/a."b.c"}}`,
+			map[string]interface{}{"a": map[string]interface{}{"b.c": false}},
+			"no", nil,
+		},
+		{
+			"custom delimiters: key with }} is addressable",
+			`<% x."a}}b" %>`,
+			map[string]interface{}{"x": map[string]interface{}{"a}}b": "delim"}},
+			"delim", []Option{Delimiters("<%", "%>")},
+		},
+		{
+			"unicode key rendered",
+			`{{ x."café.au" }}`,
+			map[string]interface{}{"x": map[string]interface{}{"café.au": "u"}},
+			"u", nil,
+		},
+		{
+			"escaped backslash key rendered",
+			`{{ x."a\\b" }}`,
+			map[string]interface{}{"x": map[string]interface{}{`a\b`: "bs"}},
+			"bs", nil,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			tmpl := New(test.options...)
+			if err := tmpl.ParseString(test.template); err != nil {
+				t.Fatalf("ParseString(%q): %v", test.template, err)
+			}
+			got, err := tmpl.RenderString(test.context)
+			if err != nil {
+				t.Fatalf("RenderString: %v", err)
+			}
+			if got != test.want {
+				t.Errorf("template %q => %q, want %q", test.template, got, test.want)
+			}
+		})
+	}
+}
+
+// TestQuotedParseErrors asserts that malformed quotes are parse errors surfaced
+// unconditionally — regardless of the SilentMiss setting (which only governs missing
+// values at render time).
+func TestQuotedParseErrors(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		template string
+		wantErr  string
+	}{
+		{"unterminated", `{{ "foo }}`, "unterminated quote"},
+		{"unterminated nested", `{{ x."foo.bar }}`, "unterminated quote"},
+		{"junk after close", `{{ x."a"b }}`, "unexpected"},
+		{"unknown escape", `{{ x."a\q" }}`, "invalid escape"},
+		{"delimiter inside key truncates", `{{ x."a}}b" }}`, "unterminated quote"},
+		{"section quote-style mismatch", `{{#a."b"}}x{{/a.'b'}}`, "closing tag"},
+		{"raw tag malformed", `{{{ x."a }}}`, "unterminated quote"},
+		{"section name malformed", `{{#x."a }}y{{/x}}`, "unterminated quote"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for _, silent := range []bool{true, false} {
+				tmpl := New(SilentMiss(silent))
+				err := tmpl.ParseString(test.template)
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Errorf("SilentMiss(%t) ParseString(%q): want error containing %q, got %v",
+						silent, test.template, test.wantErr, err)
+				}
+			}
+		})
+	}
+}
+
+// TestQuotedMissVsParseError shows the distinction: a well-formed quoted path that
+// simply misses is governed by SilentMiss (parse succeeds either way), unlike a
+// malformed quote which fails at parse time.
+func TestQuotedMissVsParseError(t *testing.T) {
+	const tmplStr = `{{ x."a.b" }}`
+
+	// SilentMiss(true): parses, renders empty, no error.
+	silent := New(SilentMiss(true))
+	if err := silent.ParseString(tmplStr); err != nil {
+		t.Fatalf("SilentMiss(true) ParseString: %v", err)
+	}
+	got, err := silent.RenderString(map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("SilentMiss(true) RenderString: unexpected error %v", err)
+	}
+	if got != "" {
+		t.Errorf("SilentMiss(true) render = %q, want empty", got)
+	}
+
+	// SilentMiss(false): parses fine, but the miss surfaces as a render error.
+	loud := New(SilentMiss(false))
+	if err := loud.ParseString(tmplStr); err != nil {
+		t.Fatalf("SilentMiss(false) ParseString: %v", err)
+	}
+	if _, err := loud.RenderString(map[string]interface{}{}); err == nil {
+		t.Errorf("SilentMiss(false) render: expected a lookup error, got nil")
+	}
+}
+
+// TestQuotedTestValue covers quoted keys inside a {{#test_value}} identifier — both
+// a successful resolution and the malformed-quote parse error on that path.
+func TestQuotedTestValue(t *testing.T) {
+	tmpl := New(TestValueSection())
+	if err := tmpl.ParseString(`{{#test_value {{x."a.b"}} "v"}}hit{{/test_value}}`); err != nil {
+		t.Fatalf("ParseString: %v", err)
+	}
+	got, err := tmpl.RenderString(map[string]interface{}{"x": map[string]interface{}{"a.b": "v"}})
+	if err != nil {
+		t.Fatalf("RenderString: %v", err)
+	}
+	if got != "hit" {
+		t.Errorf("test_value render = %q, want %q", got, "hit")
+	}
+
+	bad := New(TestValueSection())
+	if err := bad.ParseString(`{{#test_value {{x."a}} "v"}}hit{{/test_value}}`); err == nil ||
+		!strings.Contains(err.Error(), "unterminated quote") {
+		t.Errorf("malformed test_value ident: want unterminated quote error, got %v", err)
+	}
+}
+
+// TestLookupPathEmpty covers lookupPath's defensive guard for an empty path.
+func TestLookupPathEmpty(t *testing.T) {
+	ctx := map[string]interface{}{"a": 1}
+	if v, ok := lookupPath(nil, ctx); v != nil || ok {
+		t.Errorf("lookupPath(nil) = (%v, %t), want (nil, false)", v, ok)
+	}
+	if v, ok := lookupPath([]pathSegment{}, ctx); v != nil || ok {
+		t.Errorf("lookupPath([]) = (%v, %t), want (nil, false)", v, ok)
+	}
+}


### PR DESCRIPTION
## Summary

Adds quoted key segments to dotted variable lookups, so a template can address a single map/JSON key that itself contains dots:

```mustache
{{ metrics."http.request.count" }}
```

Here `http.request.count` is looked up as **one literal key** under `metrics`, instead of being split into a nested `http` → `request` → `count` path.

## Behavior

- Both `"…"` and `'…'` quotes are accepted and interchangeable.
- Interior dots are literal; `\\` and the matching quote (`\"` / `\'`) are the only escapes.
- Empty quoted keys (`""` / `''`) are valid and address the empty-string key.
- Malformed quotes (unterminated, invalid/dangling escape, junk after the closing quote) are **parse-time** errors, surfaced regardless of `SilentMiss`. A *well-formed* lookup that simply misses is still governed by `SilentMiss`.

## Design

Paths are parsed once at parse time into pre-split, dequoted segments stored on the node (`parsePath`), then resolved without re-splitting (`lookupPath`). This keeps existing dotted-lookup semantics intact and makes non-terminal quoted segments (`a."b.c".d`) and a quoted `"."` literal key resolve correctly. **No lexer change** is required.

## Limitations

- A quoted **section** name must match byte-for-byte between the opening and closing tags, including quote style (`{{#a."b.c"}}…{{/a."b.c"}}`). A mismatch is reported as a missing closing tag.
- A key cannot contain the active closing delimiter (`}}` by default); it truncates the tag and surfaces as an "unterminated quote" parse error. Use custom `Delimiters` if a key must contain `}}`.

## Testing

- Unit tables for `parsePath` / `lookupPath`, plus end-to-end coverage across `lex_test.go` (token streams), `parse_test.go` (node trees + parse errors), `example_test.go` (a runnable example), and `mustache_test.go` (render scenarios including a JSON-payload build that mixes quoted and unquoted keys).
- Covers both quote styles, escapes, empty keys, unicode, non-terminal quoted segments, quoted-`.`-vs-whole-context, dotted struct tags, sections (normal + inverse), triple-brace / `&`, custom delimiters, back-compat, and every error path.
- Full suite green including the mustache **spec** submodule; `go vet` clean; `gofmt` clean on all touched files.

## Compatibility note

`{{ x."a" }}` now resolves the key `a` (quotes stripped). Previously the quote characters were part of the key. This affects only templates/data that relied on literal quote characters in key names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)