### PR TITLE
fix: resolve zero-argument methods in struct lookups

### DIFF
--- a/lookup.go
+++ b/lookup.go
@@ -81,7 +81,7 @@ func lookup_struct(name string, reflectValue reflect.Value) (value interface{}, 
 		return field.Interface(), truth(field), true
 	}
 	method := reflectValue.MethodByName(name)
-	if method.IsValid() && method.Type().NumIn() == 1 {
+	if method.IsValid() && method.Type().NumIn() == 0 && method.Type().NumOut() >= 1 {
 		out := method.Call(nil)[0]
 		return out.Interface(), truth(out), true
 	}

--- a/method_test.go
+++ b/method_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2014 Alex Kalyvitis
+
+package mustache
+
+import "testing"
+
+type methodContext struct {
+	First string
+}
+
+// Greeting is a zero-argument method returning a single value — the case that
+// should resolve as a template variable.
+func (m methodContext) Greeting() string { return "hello" }
+
+// Nothing has no return value; it must never be invoked as a value.
+func (m methodContext) Nothing() {}
+
+// Echo requires an argument; it must never be called with zero arguments.
+func (m methodContext) Echo(s string) string { return s }
+
+// TestStructMethodLookup verifies that a zero-argument method on the context is
+// resolved and its return value rendered. This guards against the receiver-bound
+// method having NumIn()==0 (not 1), which previously caused the method branch to
+// be skipped entirely.
+func TestStructMethodLookup(t *testing.T) {
+	tmpl := New(SilentMiss(false))
+	if err := tmpl.ParseString(`{{First}}, {{Greeting}}`); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	out, err := tmpl.RenderString(methodContext{First: "hi"})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if want := "hi, hello"; out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+// TestStructMethodNoReturnIsSkipped verifies a method with no return value is not
+// treated as a variable and does not panic on the missing first result.
+func TestStructMethodNoReturnIsSkipped(t *testing.T) {
+	tmpl := New() // SilentMiss default: a miss renders empty
+	if err := tmpl.ParseString(`[{{Nothing}}]`); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	out, err := tmpl.RenderString(methodContext{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if want := "[]"; out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}
+
+// TestStructMethodWithArgIsSkipped verifies a method requiring an argument is not
+// called with zero arguments (which previously panicked) and simply does not
+// resolve.
+func TestStructMethodWithArgIsSkipped(t *testing.T) {
+	tmpl := New()
+	if err := tmpl.ParseString(`[{{Echo}}]`); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	out, err := tmpl.RenderString(methodContext{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if want := "[]"; out != want {
+		t.Errorf("got %q, want %q", out, want)
+	}
+}


### PR DESCRIPTION
## Summary

Struct-method lookups were broken: a template that references a zero-argument method on the context struct (e.g. `{{Greeting}}` backed by `func (c Ctx) Greeting() string`) silently rendered **nothing** instead of the method's return value.

## Root cause

`lookup_struct` fetches the method with `reflect.ValueOf(context).MethodByName(name)`. A method obtained from a **value** is receiver-bound, so its `Type().NumIn()` **excludes** the receiver — it is `0` for a zero-argument method. The guard, however, required `NumIn() == 1`, which is the count you'd get from the **type's** method set (where the receiver is input #0). As a result:

- ordinary zero-arg methods never matched → silently skipped;
- a method needing exactly one argument *did* satisfy `== 1`, then `method.Call(nil)` invoked it with zero args → **panic**.

## Fix

```go
- if method.IsValid() && method.Type().NumIn() == 1 {
+ if method.IsValid() && method.Type().NumIn() == 0 && method.Type().NumOut() >= 1 {
```

`NumIn() == 0` correctly matches a receiver-bound zero-arg method; `NumOut() >= 1` guards the `method.Call(nil)[0]` index so a `func()` with no return value is skipped rather than panicking.

## Tests

New `method_test.go`:
- a zero-arg method resolves and renders its return value;
- a method with no return value is skipped (no panic);
- a method requiring an argument is skipped (no panic — previously this path panicked).

Full suite green (including the spec submodule); `go vet` and `gofmt` clean.

## Independence from #23

This is unrelated to #23 (quoted keys). It touches a **disjoint** region of `lookup.go` — the method branch, which #23 leaves untouched — plus a brand-new test file. `git merge-tree` of this branch and `feat/quoted-key-lookup` merges cleanly, so the two can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)